### PR TITLE
composer.json improvement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,16 @@ cache:
 php:
   - 5.6
   - 7.0
+  - 7.1
   - 7.2
+  - 7.3
+  - 7.4
 before_install:
   ## Disabling xdebug
   - phpenv config-rm xdebug.ini
 install:
   # Update composer, install dependencies
-  - flags="--ansi --prefer-dist --no-interaction --optimize-autoloader --no-suggest --no-progress"    
+  - flags="--ansi --prefer-dist --no-interaction --optimize-autoloader --no-suggest --no-progress"
   - composer self-update
   - composer install $flags
 script:

--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,8 @@
         "friendsofphp/php-cs-fixer": "~2.1"
     },
     "autoload": {
-        "psr-0": {
-            "Json": "src/"
+        "psr-4": {
+            "Json\\": "src/Json/"
         }
     }
 }


### PR DESCRIPTION
# Changed log
- It seems that the `composer.json` file permission is incorrect.
And it should change `775` to `664` permission.
- Add other missed PHP version tests on Travis CI build.
- The `PSR-0` autoloading is deprecated and using the `PSR-4` autoloader instead.